### PR TITLE
I get the following exeption. If I change this value to string it wou…

### DIFF
--- a/examples/directPaymentPaypalMethod.md
+++ b/examples/directPaymentPaypalMethod.md
@@ -24,7 +24,7 @@ Direct payment with paypal method
     $this->item_list = array(
         'items' => array(
             array(
-                'quantity' => 1,
+                'quantity' => '1',
                 'name' => 'product name',
                 'price' => '12.35',
                 'currency' => 'EUR',


### PR DESCRIPTION
…ld be OK

Request body is not valid: [transactions[0].item_list.items[0].quantity] integer value found, but a string is required - [transactions[0].item_list.items[0]] failed to match exactly one schema - [transactions[0]] failed to match exactly one schema -